### PR TITLE
Fix tests compilation errors

### DIFF
--- a/server/bot/tiktokBot.ts
+++ b/server/bot/tiktokBot.ts
@@ -301,7 +301,7 @@ export class TikTokBot {
         await applyFilters(this.page!, {
           minFollowers,
           maxFollowers,
-          categories: this.config.categories,
+          categories: this.config!.categories,
         });
       });
 

--- a/server/bot/tiktokBotInstance.ts
+++ b/server/bot/tiktokBotInstance.ts
@@ -10,7 +10,11 @@ export class InMemoryStorage implements IStorage {
     minFollowers: 1000,
     maxFollowers: 100000,
     categories: [],
-    invitationLimit: 5
+    invitationLimit: 5,
+    actionDelay: 0,
+    retryAttempts: 0,
+    retryDelay: 0,
+    sessionTimeout: 0
   };
   private botStatus: BotStatus = { status: 'idle' };
   private dailyInviteCount: number = 0;
@@ -21,7 +25,7 @@ export class InMemoryStorage implements IStorage {
     return this.sessionData;
   }
 
-  async saveSessionData(data: SessionData): Promise<void> {
+  async saveSessionData(data: SessionData | null): Promise<void> {
     this.sessionData = data;
   }
 
@@ -29,8 +33,8 @@ export class InMemoryStorage implements IStorage {
     return this.botConfig;
   }
 
-  async updateBotConfig(config: BotConfig): Promise<void> {
-    this.botConfig = config;
+  async updateBotConfig(config: Partial<BotConfig>): Promise<void> {
+    this.botConfig = { ...this.botConfig, ...config };
   }
 
   async getBotStatus(): Promise<BotStatus> {
@@ -60,10 +64,10 @@ export class InMemoryStorage implements IStorage {
     return this.creators.find(c => c.username === username) || null;
   }
 
-  async updateCreator(creator: Creator): Promise<void> {
-    const index = this.creators.findIndex(c => c.username === creator.username);
-    if (index !== -1) {
-      this.creators[index] = creator;
+  async updateCreator(username: string, data: Partial<Creator>): Promise<void> {
+    const creator = await this.getCreatorByUsername(username);
+    if (creator) {
+      Object.assign(creator, data);
     }
   }
 
@@ -94,7 +98,11 @@ export class InMemoryStorage implements IStorage {
       minFollowers: 1000,
       maxFollowers: 100000,
       categories: [],
-      invitationLimit: 5
+      invitationLimit: 5,
+      actionDelay: 0,
+      retryAttempts: 0,
+      retryDelay: 0,
+      sessionTimeout: 0
     };
     this.botStatus = { status: 'idle' };
     this.dailyInviteCount = 0;

--- a/server/storage-impl.ts
+++ b/server/storage-impl.ts
@@ -43,7 +43,7 @@ class StorageImplementation implements IStorage {
     return this.sessionData;
   }
 
-  async saveSessionData(data: SessionData): Promise<void> {
+  async saveSessionData(data: SessionData | null): Promise<void> {
     this.sessionData = data;
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,11 @@
-import { BotConfig, BotStatus, SessionData, Creator, InsertActivityLog } from '../shared/schema';
+import {
+  BotConfig,
+  BotStatus,
+  SessionData,
+  Creator,
+  ActivityLog,
+  InsertActivityLog,
+} from '../shared/schema';
 
 export interface IStorage {
   // Bot Configuration
@@ -7,7 +14,7 @@ export interface IStorage {
   
   // Session Management
   getSessionData(): Promise<SessionData | null>;
-  saveSessionData(data: SessionData): Promise<void>;
+  saveSessionData(data: SessionData | null): Promise<void>;
   
   // Bot Status
   getBotStatus(): Promise<BotStatus>;
@@ -32,3 +39,12 @@ export interface IStorage {
 
 // Implementation can be added here or in separate files for different storage backends
 // For example: SQLiteStorage, PostgresStorage, etc.
+
+export type {
+  BotConfig,
+  BotStatus,
+  SessionData,
+  Creator,
+  ActivityLog,
+  InsertActivityLog,
+};

--- a/server/storage/index.ts
+++ b/server/storage/index.ts
@@ -44,7 +44,7 @@ export interface BotStatus {
 export interface IStorage {
   // Session management
   getSessionData(): Promise<SessionData | null>;
-  saveSessionData(data: SessionData): Promise<void>;
+  saveSessionData(data: SessionData | null): Promise<void>;
   
   // Bot configuration
   getBotConfig(): Promise<BotConfig>;

--- a/server/storage/memory.ts
+++ b/server/storage/memory.ts
@@ -43,7 +43,7 @@ export class MemoryStorage implements IStorage {
     return this.sessionData;
   }
 
-  async saveSessionData(data: SessionData): Promise<void> {
+  async saveSessionData(data: SessionData | null): Promise<void> {
     this.sessionData = data;
   }
 

--- a/server/storage/memoryStorage.ts
+++ b/server/storage/memoryStorage.ts
@@ -43,7 +43,7 @@ class MemoryStorage implements IStorage {
     return this.sessionData;
   }
 
-  async saveSessionData(data: SessionData): Promise<void> {
+  async saveSessionData(data: SessionData | null): Promise<void> {
     this.sessionData = data;
   }
 

--- a/server/storage/storage-impl.ts
+++ b/server/storage/storage-impl.ts
@@ -43,7 +43,7 @@ export class StorageImplementation implements IStorage {
     return this.sessionData;
   }
 
-  async saveSessionData(data: SessionData): Promise<void> {
+  async saveSessionData(data: SessionData | null): Promise<void> {
     this.sessionData = data;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -29,6 +29,18 @@ export interface BotConfig {
   maxFollowers: number;
   categories: string[];
   invitationLimit: number;
+  actionDelay: number;
+  retryAttempts: number;
+  retryDelay: number;
+  sessionTimeout: number;
+  maxConcurrentRequests?: number;
+  requestTimeout?: number;
+  maxRequestsPerMinute?: number;
+  userAgent?: string;
+  proxyUrl?: string;
+  logLevel?: string;
+  screenshotOnError?: boolean;
+  maxDailyInvites?: number;
 }
 
 export interface Creator {
@@ -46,12 +58,24 @@ export interface ActivityLog {
   metadata?: Record<string, any>;
 }
 
+// Extended log type used when inserting logs into storage
+export interface InsertActivityLog extends ActivityLog {
+  details?: any;
+}
+
 export interface BotStatus {
   status: 'idle' | 'running' | 'error' | 'initialized' | 'stopped';
   lastError?: string;
   lastActivity?: ActivityLog;
   isRateLimited?: boolean;
   queueLength?: number;
+  lastLoginTime?: Date;
+  invitationsSent?: number;
+  successRate?: number;
+  currentOperation?: string;
+  uptime?: number;
+  memoryUsage?: number;
+  cpuUsage?: number;
 }
 
 export interface StorageConfig {

--- a/test/bot/bot-test.ts
+++ b/test/bot/bot-test.ts
@@ -78,6 +78,18 @@ class MockStorage implements IStorage {
     }
   }
 
+  async getDailyInviteCount(): Promise<number> {
+    return 0;
+  }
+
+  async incrementDailyInviteCount(): Promise<void> {
+    /* noop */
+  }
+
+  async resetDailyInviteCount(): Promise<void> {
+    /* noop */
+  }
+
   async cleanup(): Promise<void> {
     this.botConfig = null;
     this.botStatus = {

--- a/test/bot/e2e-test.ts
+++ b/test/bot/e2e-test.ts
@@ -41,7 +41,11 @@ describe('End-to-End Bot Tests', () => {
         minFollowers: 1000,
         maxFollowers: 100000,
         categories: ["Fashion"],
-        invitationLimit: 5
+        invitationLimit: 5,
+        actionDelay: 0,
+        retryAttempts: 0,
+        retryDelay: 0,
+        sessionTimeout: 0
       };
       await storage.updateBotConfig(config);
 

--- a/test/bot/integration-test.ts
+++ b/test/bot/integration-test.ts
@@ -67,7 +67,11 @@ describe('Bot Integration Tests', () => {
         minFollowers: 1000,
         maxFollowers: 100000,
         categories: ["Fashion"],
-        invitationLimit: 5
+        invitationLimit: 5,
+        actionDelay: 0,
+        retryAttempts: 0,
+        retryDelay: 0,
+        sessionTimeout: 0
       };
       await storage.updateBotConfig(config);
     });

--- a/test/bot/login-test.ts
+++ b/test/bot/login-test.ts
@@ -51,7 +51,7 @@ describe('TikTok Login Flow Tests', () => {
       
       // Should throw an error for invalid credentials
       expect.fail('Should have thrown an error for invalid credentials');
-    } catch (error) {
+    } catch (error: any) {
       expect(error).to.be.an('error');
       expect(error.message).to.include('Login failed');
     }
@@ -70,7 +70,7 @@ describe('TikTok Login Flow Tests', () => {
       });
       
       expect.fail('Should have thrown an error for network failure');
-    } catch (error) {
+    } catch (error: any) {
       expect(error).to.be.an('error');
       expect(error.message).to.include('Login failed');
     } finally {

--- a/test/production-test.ts
+++ b/test/production-test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it, before, Context } from 'mocha';
-import { TiktokBot } from '../server/bot/tiktokBot';
+import { TikTokBot } from '../server/bot/tiktokBot';
 import type { IStorage } from '../server/storage';
 import { BotConfig, BotStatus, SessionData, Creator, InsertActivityLog } from '../shared/schema';
 import { Browser, Page } from 'puppeteer';
@@ -14,7 +14,7 @@ import {
 describe('TikTok Affiliator Production Tests', () => {
   // Critical Path Tests
   describe('Critical Path', () => {
-    let bot: TiktokBot;
+    let bot: TikTokBot;
     let storage: IStorage;
 
     before(async function(this: Context) {
@@ -37,13 +37,16 @@ describe('TikTok Affiliator Production Tests', () => {
           proxyUrl: undefined,
           logLevel: 'info',
           screenshotOnError: true,
-          maxDailyInvites: 100
+      maxDailyInvites: 100
         }),
         getSessionData: async (): Promise<SessionData | null> => null,
         saveSessionData: async (): Promise<void> => {},
-        updateBotStatus: async (status: Partial<BotStatus>): Promise<void> => {},
-        addActivityLog: async (log: InsertActivityLog): Promise<void> => {},
-        saveCreators: async (creators: Creator[]): Promise<void> => {},
+        updateBotConfig: async (_: Partial<BotConfig>): Promise<void> => {},
+        updateBotStatus: async (_: Partial<BotStatus>): Promise<void> => {},
+        addActivityLog: async (_: InsertActivityLog): Promise<void> => {},
+        saveCreators: async (_: Creator[]): Promise<void> => {},
+        getCreatorByUsername: async (_: string): Promise<Creator | null> => null,
+        updateCreator: async (_: string, __: Partial<Creator>): Promise<void> => {},
         getBotStatus: async (): Promise<BotStatus> => ({
           status: 'initialized',
           lastLoginTime: new Date(),
@@ -56,7 +59,7 @@ describe('TikTok Affiliator Production Tests', () => {
         cleanup: async (): Promise<void> => {}
       };
       
-      bot = new TiktokBot(storage);
+      bot = new TikTokBot(storage);
     });
 
 


### PR DESCRIPTION
## Summary
- update storage interface and re-export types
- update shared schema definitions
- fix InMemoryStorage updateCreator and config
- adjust tests to match new interfaces

## Testing
- `npm test` *(fails: Property 'init' does not exist on type 'TikTokBot')*