### PR TITLE
refactor storage exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,9 @@
         "typescript": "5.6.3",
         "vite": "^6.3.5"
       },
+      "engines": {
+        "node": ">=18"
+      },
       "optionalDependencies": {
         "bufferutil": "^4.0.8"
       }

--- a/project mermaid.txt
+++ b/project mermaid.txt
@@ -24,7 +24,7 @@ TikTokAffiliator/
 
 Key Files:
 1. Bot Configuration: server/bot/tiktokBot.ts
-2. Storage Interface: server/storage/index.ts
+2. Storage Interface: server/storage.ts
 3. API Routes: server/routes/botRoutes.ts
 4. Type Definitions: shared/schema.ts
 5. Tests: test/bot/*

--- a/server/bot/bot.ts
+++ b/server/bot/bot.ts
@@ -1,7 +1,7 @@
 import { Browser, Page } from 'puppeteer';
 import puppeteer from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
-import { IStorage } from '../storage/index';
+import { IStorage } from '../storage';
 import { BotConfig, BotStatus } from '../../shared/schema';
 import { logger } from './utils/logger';
 import { RateLimiter } from './utils/rateLimiter';

--- a/server/bot/enhancedTiktokBot.ts
+++ b/server/bot/enhancedTiktokBot.ts
@@ -1,7 +1,7 @@
 import { Browser, Page } from 'puppeteer';
 import puppeteer from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
-import { IStorage } from '../storage/index';
+import { IStorage } from '../storage';
 import { BotConfig, BotStatus } from '../../shared/schema';
 import { logger } from './utils/logger';
 import { RateLimiter } from './utils/rateLimiter';

--- a/server/bot/tiktokBot.ts
+++ b/server/bot/tiktokBot.ts
@@ -5,7 +5,7 @@
 import { Browser, Page } from 'puppeteer';
 import puppeteer from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
-import { IStorage } from '../storage/index';
+import { IStorage } from '../storage';
 import { BotConfig, BotStatus } from '../../shared/schema';
 
 // Placeholder logger

--- a/server/bot/tiktokBotInstance.ts
+++ b/server/bot/tiktokBotInstance.ts
@@ -1,5 +1,5 @@
 import { TikTokBot } from './tiktokBot';
-import { IStorage, SessionData, BotConfig, Creator, ActivityLog, BotStatus } from '../storage/index';
+import { IStorage, SessionData, BotConfig, Creator, ActivityLog, BotStatus } from '../storage';
 
 // Export the InMemoryStorage class so it can be used in tests
 export class InMemoryStorage implements IStorage {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,3 @@
-// Re-export the shared interfaces so consumers only import from this module
 export type {
   SessionData,
   BotConfig,
@@ -6,7 +5,7 @@ export type {
   ActivityLog,
   InsertActivityLog,
   BotStatus,
-} from '../../shared/schema';
+} from '../shared/schema';
 
 import type {
   SessionData,
@@ -15,7 +14,7 @@ import type {
   ActivityLog,
   InsertActivityLog,
   BotStatus,
-} from '../../shared/schema';
+} from '../shared/schema';
 
 export interface IStorage {
   // Session management
@@ -25,28 +24,28 @@ export interface IStorage {
   // Bot configuration
   getBotConfig(): Promise<BotConfig>;
   updateBotConfig(config: Partial<BotConfig>): Promise<void>;
-  
+
   // Bot status
   getBotStatus(): Promise<BotStatus>;
   updateBotStatus(statusUpdate: Partial<BotStatus>): Promise<void>;
-  
+
   // Activity logging
   addActivityLog(log: InsertActivityLog): Promise<void>;
   getActivityLogs(page: number, limit: number, type?: string): Promise<InsertActivityLog[]>;
   clearActivityLogs(): Promise<void>;
-  
+
   // Creator management
   saveCreators(creators: Creator[]): Promise<void>;
   getCreators(): Promise<Creator[]>;
   getCreatorByUsername(username: string): Promise<Creator | null>;
   updateCreator(username: string, data: Partial<Creator>): Promise<void>;
   listCreators(page: number, limit: number): Promise<Creator[]>;
-  
+
   // Daily invite tracking
   getDailyInviteCount(): Promise<number>;
   incrementDailyInviteCount(): Promise<void>;
   resetDailyInviteCount(): Promise<void>;
-  
+
   // Cleanup
   cleanup(): Promise<void>;
 }

--- a/server/storage/storage-impl.ts
+++ b/server/storage/storage-impl.ts
@@ -1,5 +1,5 @@
 import { BotConfig, BotStatus, SessionData, Creator, InsertActivityLog } from '../../shared/schema';
-import { IStorage } from '../storage/index';
+import { IStorage } from '../storage';
 
 export class StorageImplementation implements IStorage {
   private botConfig: BotConfig | null = null;

--- a/test/bot/bot-test.ts
+++ b/test/bot/bot-test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import { TikTokBot } from '../../server/bot/bot';
-import { IStorage } from '../../server/storage/index';
+import { IStorage } from '../../server/storage';
 import { BotConfig, BotStatus } from '../../shared/schema';
 
 // Mock storage implementation for testing

--- a/test/bot/e2e-test.ts
+++ b/test/bot/e2e-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TikTokBot } from '../../server/bot/tiktokBot';
 import { InMemoryStorage } from '../../server/bot/tiktokBotInstance';
-import { SessionData, Creator, BotConfig } from '../../server/storage/index';
+import { SessionData, Creator, BotConfig } from '../../server/storage';
 
 describe('End-to-End Bot Tests', () => {
   let storage: InMemoryStorage;

--- a/test/bot/integration-test.ts
+++ b/test/bot/integration-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TikTokBot } from '../../server/bot/tiktokBot';
 import { InMemoryStorage } from '../../server/bot/tiktokBotInstance';
-import { SessionData, Creator, BotConfig } from '../../server/storage/index';
+import { SessionData, Creator, BotConfig } from '../../server/storage';
 
 describe('Bot Integration Tests', () => {
   let storage: InMemoryStorage;

--- a/test/production-test.ts
+++ b/test/production-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it, before, Context } from 'mocha';
 import { TikTokBot } from '../server/bot/tiktokBot';
-import type { IStorage } from '../server/storage/index';
+import type { IStorage } from '../server/storage';
 import { BotConfig, BotStatus, SessionData, Creator, InsertActivityLog } from '../shared/schema';
 
 describe('TikTok Affiliator Production Tests', () => {

--- a/test/run-tests.ts
+++ b/test/run-tests.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { TikTokBot } from '../server/bot/tiktokBot';
-import { IStorage } from '../server/storage/index';
+import { IStorage } from '../server/storage';
 import { BotConfig, BotStatus, SessionData } from '../shared/schema';
 
 // Mock storage implementation for testing


### PR DESCRIPTION
## Summary
- centralize storage interfaces in `server/storage.ts`
- delete the obsolete `server/storage/index.ts`
- update references to the new storage module

## Testing
- `npm test` *(fails: running as root without --no-sandbox)*