### PR TITLE
Fix missing build on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ npm test
 Use the compiled server in production:
 
 ```bash
-npm run build
+npm run build                # or simply `npm start` which runs the build step automatically
 npm install -g pm2
 pm2 start dist/index.js --name tiktok-affiliator
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "prestart": "npm run build",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- ensure server is compiled before running `npm start`
- document new `npm start` behavior in README

## Testing
- `npm test` *(fails: server/routes/index.ts TS2345)*