### PR TITLE
Fix start error by building automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "prestart": "npm run build",
-    "start": "NODE_ENV=production node dist/index.js",
+    "start": "NODE_ENV=production node scripts/start.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "mocha -r ts-node/register test/**/*.ts",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,12 @@
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+const distFile = resolve('dist/index.js');
+if (!existsSync(distFile)) {
+  console.log('dist/index.js not found, running build...');
+  execSync('npm run build', { stdio: 'inherit' });
+}
+await import(pathToFileURL(distFile));
+


### PR DESCRIPTION
## Summary
- ensure production startup builds the project if needed
- update start script to run the new helper

## Testing
- `npm test` *(fails: StorageImplementation missing `listCreators` type)*