### PR TITLE
Fix Render build failing due to missing dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "npm install --include=dev && vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node scripts/start.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- fix build script to install dev dependencies before bundling

## Testing
- `npm test` *(fails: Failed to launch the browser process)*
- `npm run check` *(fails: TypeScript errors)*