### PR TITLE
Fix static routing and puppeteer launch

### DIFF
--- a/server/bot/tiktokBot.ts
+++ b/server/bot/tiktokBot.ts
@@ -95,7 +95,7 @@ export class TikTokBot {
       this.browser = await puppeteer.launch({
         headless: false,
         defaultViewport: null,
-        args: ['--start-maximized'],
+        args: ['--start-maximized', '--no-sandbox', '--disable-setuid-sandbox'],
       });
       // Ensure browser is not null
       if (!this.browser) throw new Error('Browser failed to launch');

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,9 +4,10 @@ config();
 
 import express from 'express';
 import cors from 'cors';
+import path from 'path';
 import { registerRoutes } from './routes';
 import { storage } from './storage/storage-impl';
-import { CONFIG } from './config';
+import { CONFIG, PATHS } from './config';
 
 async function main() {
   // Create Express app
@@ -18,8 +19,16 @@ async function main() {
   }));
   app.use(express.json());
 
-  // Register routes
+  // Register API routes
   const server = await registerRoutes(app);
+
+  // Serve static frontend in production
+  if (CONFIG.NODE_ENV === 'production') {
+    app.use(express.static(PATHS.public));
+    app.get('*', (_req, res) => {
+      res.sendFile(path.resolve(PATHS.public, 'index.html'));
+    });
+  }
 
   // Start server
   const port = CONFIG.PORT;


### PR DESCRIPTION
## Summary
- serve built frontend in production mode
- include sandbox flags when launching Puppeteer for manual login

## Testing
- `npm test` *(fails: failed to launch the browser process due to missing display)*