### PR TITLE
Add Render deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ pm2 start dist/index.js --name tiktok-affiliator
 
 See [PRODUCTION.md](PRODUCTION.md) for the full deployment guide.
 
+## Deployment on Render
+
+If you're hosting the bot on [Render](https://render.com), Puppeteer needs a
+Chrome binary to be installed during the build step. Add a `render.yaml` file in
+the repository root with the following configuration:
+
+```yaml
+services:
+  - type: web
+    name: tiktok-affiliator
+    env: node
+    buildCommand: |
+      npm ci
+      npx puppeteer browsers install chrome
+      npm run build-only
+    startCommand: npm run start
+```
+
+This downloads Chrome for Puppeteer and builds the project before Render runs
+`npm run start`.
+
 ## Contributing
 
 1. Fork the repository

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm install --include=dev && npm run build-only",
     "build-only": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node scripts/start.js",
-    "postinstall": "npm run build-only",
+    "postinstall": "npx puppeteer browsers install chrome && npm run build-only",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "mocha -r ts-node/register test/**/*.ts",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: tiktok-affiliator
+    env: node
+    buildCommand: |
+      npm ci
+      npx puppeteer browsers install chrome
+      npm run build-only
+    startCommand: npm run start


### PR DESCRIPTION
## Summary
- document how to deploy to Render and ensure Chrome install
- run Chrome installation in postinstall
- include sample render.yaml

## Testing
- `npm test` *(fails: Login failed: net::ERR_PROXY_CONNECTION_FAILED)*