### PR TITLE
Fix manual login error propagation

### DIFF
--- a/server/bot/tiktokBot.ts
+++ b/server/bot/tiktokBot.ts
@@ -91,7 +91,7 @@ export class TikTokBot {
   /**
    * startManualLogin
    */
-  async startManualLogin(): Promise<boolean> {
+  async startManualLogin(): Promise<void> {
     logger.info('bot', 'Starting manual login process');
     try {
       this.browser = await puppeteer.launch({
@@ -128,7 +128,7 @@ export class TikTokBot {
       await this.browser.close();
       this.browser = null;
       this.page = null;
-      return true;
+      return;
     } catch (error) {
       logger.error('bot', 'Manual login failed', error);
       if (this.browser) {
@@ -136,7 +136,7 @@ export class TikTokBot {
       }
       this.browser = null;
       this.page = null;
-      return false;
+      throw error;
     }
   }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -29,13 +29,10 @@ export async function registerRoutes(app: Application, botInstance: TikTokBot = 
   // Manual login to capture a session
   apiRouter.post("/manual-login", async (_req: Request, res: Response) => {
     try {
-      const success = await botInstance.startManualLogin();
-      if (success) {
-        return res.json({ message: "Manual login completed successfully" });
-      }
-      return res.status(500).json({ error: "Manual login failed or was cancelled" });
+      await botInstance.startManualLogin();
+      return res.json({ message: "Manual login completed successfully" });
     } catch (err: any) {
-      return res.status(500).json({ error: err.message || "Unknown error" });
+      return res.status(500).json({ error: err.message || "Manual login failed" });
     }
   });
 


### PR DESCRIPTION
## Summary
- return errors from startManualLogin instead of swallowing them
- simplify manual-login route to expose underlying error

## Testing
- `npm test` *(fails: Failed to launch the browser process)*