### PR TITLE
Fix missing Chrome issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ npm install
 cd ..
 ```
 
+The server's start script will check for a Chrome binary and automatically
+download it if necessary. If you run into errors about Puppeteer not finding
+Chrome, you can manually install it with:
+
+```bash
+npm run install-chrome
+```
+
 3. Copy `.env.example` to `.env` and update values:
 ```env
 NODE_ENV=development

--- a/scripts/ensureChrome.js
+++ b/scripts/ensureChrome.js
@@ -1,0 +1,11 @@
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+import puppeteer from 'puppeteer';
+
+export function ensureChromeInstalled() {
+  const chromePath = puppeteer.executablePath();
+  if (!existsSync(chromePath)) {
+    console.log('Chrome binary not found. Installing Chrome for Puppeteer...');
+    execSync('npx puppeteer browsers install chrome', { stdio: 'inherit' });
+  }
+}

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -2,11 +2,13 @@ import { existsSync } from 'fs';
 import { execSync } from 'child_process';
 import { resolve } from 'path';
 import { pathToFileURL } from 'url';
+import { ensureChromeInstalled } from './ensureChrome.js';
 
 const distFile = resolve('dist/index.js');
 if (!existsSync(distFile)) {
   console.log('dist/index.js not found, running build...');
   execSync('npm run build-only', { stdio: 'inherit' });
 }
+ensureChromeInstalled();
 await import(pathToFileURL(distFile));
 


### PR DESCRIPTION
## Summary
- auto-install Puppeteer's Chrome before server startup
- document Chrome installation step in README

## Testing
- `npm test` *(fails: Failed to launch the browser process)*