### PR TITLE
Fix render build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-only": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node scripts/start.js",
     "install-chrome": "puppeteer browsers install chrome",
-    "postinstall": "npm run install-chrome && npm run build-only",
+    "postinstall": "node scripts/postinstall.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "mocha -r ts-node/register test/**/*.ts",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+
+try {
+  execSync('npm run install-chrome', { stdio: 'inherit' });
+} catch (err) {
+  console.error('Failed to install Chrome:', err);
+}
+
+const vitePath = 'node_modules/.bin/vite';
+if (existsSync(vitePath)) {
+  try {
+    execSync('npm run build-only', { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Build failed:', err);
+    process.exitCode = 1;
+  }
+} else {
+  console.log('Skipping build step because dev dependencies are not installed.');
+}


### PR DESCRIPTION
## Summary
- update `postinstall` to skip the build when dev deps aren't installed
- add script to handle optional build step and chrome install

## Testing
- `npm test` *(fails: ERR_PROXY_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_b_683a23679c3c8321a28b2bada3868ebe