### PR TITLE
Handle manual login failures

### DIFF
--- a/server/bot/tiktokBot.ts
+++ b/server/bot/tiktokBot.ts
@@ -135,6 +135,11 @@ export class TikTokBot {
       await this.storage.saveSessionData(session);
 
       logger.info('bot', 'Manual login successful, session saved');
+      await this.storage.updateBotStatus({
+        status: 'initialized',
+        lastLoginTime: new Date(),
+        lastError: undefined
+      });
       await this.browser.close();
       this.browser = null;
       this.page = null;
@@ -146,6 +151,10 @@ export class TikTokBot {
       }
       this.browser = null;
       this.page = null;
+      await this.storage.updateBotStatus({
+        status: 'error',
+        lastError: (error as Error)?.message || String(error)
+      });
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- update the bot's status when manual login succeeds or fails

## Testing
- `npm test` *(fails: net::ERR_PROXY_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_b_683a2b7436188321b4f222d60a0691bf